### PR TITLE
bundleId renamed to com.digitalcave.redrabbit

### DIFF
--- a/packages/mobile/android/app/BUCK
+++ b/packages/mobile/android/app/BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.redrabbit",
+    package = "com.digitalcave.redrabbit",
 )
 
 android_resource(
     name = "res",
-    package = "com.redrabbit",
+    package = "com.digitalcave.redrabbit",
     res = "src/main/res",
 )
 

--- a/packages/mobile/android/app/build.gradle
+++ b/packages/mobile/android/app/build.gradle
@@ -128,7 +128,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.redrabbit"
+        applicationId "com.digitalcave.redrabbit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/packages/mobile/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.redrabbit">
+  package="com.digitalcave.redrabbit">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/packages/mobile/android/app/src/main/java/com/digitalcave/redrabbit/MainActivity.java
+++ b/packages/mobile/android/app/src/main/java/com/digitalcave/redrabbit/MainActivity.java
@@ -1,4 +1,4 @@
-package com.redrabbit;
+package com.digitalcave.redrabbit;
 
 import com.facebook.react.ReactActivity;
 

--- a/packages/mobile/android/app/src/main/java/com/digitalcave/redrabbit/MainApplication.java
+++ b/packages/mobile/android/app/src/main/java/com/digitalcave/redrabbit/MainApplication.java
@@ -1,4 +1,4 @@
-package com.redrabbit;
+package com.digitalcave.redrabbit;
 
 import android.app.Application;
 import android.content.Context;


### PR DESCRIPTION
Initially the app comes in both platflorms with unique identifiers that will identify the app on the play store and app store, they are different by default but a good practice is to use a unique one for both platforms.
 I set the bundleId (iOS) and aplicationId (Android) as `com.digitalcave.redrabbit`